### PR TITLE
Fix nginx syntax to disable error logs

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -23,8 +23,8 @@ http {
   types_hash_max_size 2048;
   include /etc/nginx/mime.types;
   default_type application/octet-stream;
-  access_log off;
-  error_log off;
+  access_log /dev/null;
+  error_log /dev/null;
   gzip on;
   gzip_disable "msie6";
   include /etc/nginx/conf.d/*.conf;


### PR DESCRIPTION
Setting `error_log off` will create a file named `off` in the directory where nginx is running.

See:
https://www.wpoven.com/tutorial/how-to-disable-nginx-logs-on-your-server/
http://nginx.org/en/docs/ngx_core_module.html#error_log